### PR TITLE
Update README to fix stale references and incorrect info

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,7 +116,6 @@ dotnet test tests/xUnitTests
 ## Configuration
 
 - Database connection and credentials are defined in `docker-compose.yml`.
-- Certificates for HTTPS are mapped from your local machine (see Docker volumes).
 - Environment variables and ASP.NET Core settings can be adjusted in Docker or via `launchSettings.json`.
 
 <p align="right">(<a href="#Biller">back to top</a>)</p>

--- a/README.md
+++ b/README.md
@@ -9,9 +9,9 @@
 
 <!-- PROJECT LOGO -->
 <div align="center">
-  <a href="https://github.com/aldisadom/APIProjectTemplate">
+  <a href="https://github.com/aldisadom/Biller">
     <img src="images/logo.png" alt="Logo" width="80" height="80">
-  </a>  
+  </a>
   <p align="center">
     <a href="/docs/README_en.md">English</a>
   </p>
@@ -55,13 +55,14 @@ Biller is a modular, multi-layered billing and invoicing platform. It features a
 ## Project Structure
 
 - `src/Application` – Business logic, use cases, and application services.
-- `src/Client` – External API calls.
+- `src/Client` – .NET HTTP clients for external API calls.
 - `src/Common` – Shared types and utilities.
 - `src/Contracts` – Interfaces and data contracts for API and domain exchange.
 - `src/Domain` – Core domain models, aggregates, and logic.
 - `src/Infrastructure` – Implementation of persistence, external integrations, etc.
 - `src/Validators` – Input validation logic.
 - `src/WebAPI` – ASP.NET Core Web API entry point and infrastructure.
+- `tests/xUnitTests` – Unit and integration tests.
 
 <p align="right">(<a href="#Biller">back to top</a>)</p>
 
@@ -69,9 +70,8 @@ Biller is a modular, multi-layered billing and invoicing platform. It features a
 
 ### Prerequisites
 
-- [.NET 6+ SDK](https://dotnet.microsoft.com/download)
+- [.NET 8+ SDK](https://dotnet.microsoft.com/download)
 - [Docker](https://www.docker.com/get-started)
-- [Node.js](https://nodejs.org/) (if developing the client)
 
 <p align="right">(<a href="#Biller">back to top</a>)</p>
 
@@ -90,8 +90,8 @@ This starts:
 - Liquibase for database migrations (`liquibase`)
 
 Access:
-- API: [https://localhost:8091](https://localhost:8091)
-- Swagger UI: [https://localhost:8091/swagger](https://localhost:8091/swagger)
+- API: [http://localhost:8090](http://localhost:8090)
+- Swagger UI: [http://localhost:8090/swagger](http://localhost:8090/swagger)
 - pgAdmin: [http://localhost:8888](http://localhost:8888)
 
 <p align="right">(<a href="#Biller">back to top</a>)</p>
@@ -105,12 +105,10 @@ cd src/WebAPI
 dotnet run
 ```
 
-To run the client (if present):
+To run the tests:
 
 ```sh
-cd src/Client
-npm install
-npm start
+dotnet test tests/xUnitTests
 ```
 
 <p align="right">(<a href="#Biller">back to top</a>)</p>
@@ -138,38 +136,18 @@ Issues and pull requests are welcome! Please see the [LICENSE.txt](LICENSE.txt) 
 <!-- MARKDOWN LINKS & IMAGES -->
 <!-- https://www.markdownguide.org/basic-syntax/#reference-style-links -->
 <!-- git -->
-[contributors-shield]: https://img.shields.io/github/contributors/aldisadom/APIProjectTemplate.svg?style=for-the-badge
-[contributors-url]: https://github.com/aldisadom/APIProjectTemplate/graphs/contributors
-[forks-shield]: https://img.shields.io/github/forks/aldisadom/APIProjectTemplate.svg?style=for-the-badge
-[forks-url]: https://github.com/aldisadom/APIProjectTemplate/network/members
-[stars-shield]: https://img.shields.io/github/stars/aldisadom/APIProjectTemplate.svg?style=for-the-badge
-[stars-url]: https://github.com/aldisadom/APIProjectTemplate/stargazers
-[issues-shield]: https://img.shields.io/github/issues/aldisadom/APIProjectTemplate.svg?style=for-the-badge
-[issues-url]: https://github.com/aldisadom/APIProjectTemplate/issues
-[license-shield]: https://img.shields.io/github/license/aldisadom/APIProjectTemplate.svg?style=for-the-badge
-[license-url]: https://github.com/aldisadom/APIProjectTemplate/blob/master/LICENSE.txt
+[contributors-shield]: https://img.shields.io/github/contributors/aldisadom/Biller.svg?style=for-the-badge
+[contributors-url]: https://github.com/aldisadom/Biller/graphs/contributors
+[forks-shield]: https://img.shields.io/github/forks/aldisadom/Biller.svg?style=for-the-badge
+[forks-url]: https://github.com/aldisadom/Biller/network/members
+[stars-shield]: https://img.shields.io/github/stars/aldisadom/Biller.svg?style=for-the-badge
+[stars-url]: https://github.com/aldisadom/Biller/stargazers
+[issues-shield]: https://img.shields.io/github/issues/aldisadom/Biller.svg?style=for-the-badge
+[issues-url]: https://github.com/aldisadom/Biller/issues
+[license-shield]: https://img.shields.io/github/license/aldisadom/Biller.svg?style=for-the-badge
+[license-url]: https://github.com/aldisadom/Biller/blob/master/LICENSE.txt
 
 <!-- my links -->
 [linkedin-shield]: https://img.shields.io/badge/-LinkedIn-black.svg?style=for-the-badge&logo=linkedin&colorB=555
 [linkedin-url]: https://linkedin.com/in/aldis-adomavicius/
 
-<!-- product links -->
-[product-screenshot]: images/screenshot.png
-[Next.js]: https://img.shields.io/badge/next.js-000000?style=for-the-badge&logo=nextdotjs&logoColor=white
-
-<!-- used tools logos -->
-[Next-url]: https://nextjs.org/
-[React.js]: https://img.shields.io/badge/React-20232A?style=for-the-badge&logo=react&logoColor=61DAFB
-[React-url]: https://reactjs.org/
-[Vue.js]: https://img.shields.io/badge/Vue.js-35495E?style=for-the-badge&logo=vuedotjs&logoColor=4FC08D
-[Vue-url]: https://vuejs.org/
-[Angular.io]: https://img.shields.io/badge/Angular-DD0031?style=for-the-badge&logo=angular&logoColor=white
-[Angular-url]: https://angular.io/
-[Svelte.dev]: https://img.shields.io/badge/Svelte-4A4A55?style=for-the-badge&logo=svelte&logoColor=FF3E00
-[Svelte-url]: https://svelte.dev/
-[Laravel.com]: https://img.shields.io/badge/Laravel-FF2D20?style=for-the-badge&logo=laravel&logoColor=white
-[Laravel-url]: https://laravel.com
-[Bootstrap.com]: https://img.shields.io/badge/Bootstrap-563D7C?style=for-the-badge&logo=bootstrap&logoColor=white
-[Bootstrap-url]: https://getbootstrap.com
-[JQuery.com]: https://img.shields.io/badge/jQuery-0769AD?style=for-the-badge&logo=jquery&logoColor=white
-[JQuery-url]: https://jquery.com 


### PR DESCRIPTION
- Fix all GitHub links from APIProjectTemplate to Biller
- Correct API port from 8091 to 8090 (matching docker-compose)
- Update .NET 6+ to .NET 8+
- Remove incorrect Node.js client instructions; add dotnet test
- Add tests/xUnitTests to project structure
- Remove unused framework logo links