### PR TITLE
Add unit tests for all validators

### DIFF
--- a/tests/xUnitTests/Validators/Customer/CustomerAddValidatorTest.cs
+++ b/tests/xUnitTests/Validators/Customer/CustomerAddValidatorTest.cs
@@ -1,0 +1,176 @@
+using Contracts.Requests.Customer;
+using FluentAssertions;
+using FluentValidation;
+using Validators.Customer;
+
+namespace xUnitTests.Validators.Customer;
+
+public class CustomerAddValidatorTest
+{
+    private readonly CustomerAddValidator _validator = new();
+
+    private static CustomerAddRequest ValidRequest() => new()
+    {
+        SellerId = Guid.NewGuid(),
+        CompanyNumber = "123456",
+        CompanyName = "Test Company",
+        Street = "Test Street 1",
+        City = "Test City",
+        State = "Test State",
+        Email = "test@example.com",
+        Phone = "1234567890",
+        InvoiceName = "Test Invoice Name"
+    };
+
+    [Fact]
+    public void Validate_ValidRequest_IsValid()
+    {
+        // Arrange
+        var request = ValidRequest();
+
+        // Act
+        var result = _validator.Validate(request);
+
+        // Assert
+        result.IsValid.Should().BeTrue();
+    }
+
+    [Fact]
+    public void Validate_EmptySellerId_IsInvalid()
+    {
+        // Arrange
+        var request = ValidRequest();
+        request.SellerId = Guid.Empty;
+
+        // Act
+        var result = _validator.Validate(request);
+
+        // Assert
+        result.IsValid.Should().BeFalse();
+        result.Errors.Should().Contain(e => e.PropertyName == nameof(request.SellerId));
+    }
+
+    [Fact]
+    public void Validate_EmptyCompanyNumber_IsInvalid()
+    {
+        // Arrange
+        var request = ValidRequest();
+        request.CompanyNumber = string.Empty;
+
+        // Act
+        var result = _validator.Validate(request);
+
+        // Assert
+        result.IsValid.Should().BeFalse();
+        result.Errors.Should().Contain(e => e.PropertyName == nameof(request.CompanyNumber));
+    }
+
+    [Fact]
+    public void Validate_EmptyCompanyName_IsInvalid()
+    {
+        // Arrange
+        var request = ValidRequest();
+        request.CompanyName = string.Empty;
+
+        // Act
+        var result = _validator.Validate(request);
+
+        // Assert
+        result.IsValid.Should().BeFalse();
+        result.Errors.Should().Contain(e => e.PropertyName == nameof(request.CompanyName));
+    }
+
+    [Fact]
+    public void Validate_EmptyStreet_IsInvalid()
+    {
+        // Arrange
+        var request = ValidRequest();
+        request.Street = string.Empty;
+
+        // Act
+        var result = _validator.Validate(request);
+
+        // Assert
+        result.IsValid.Should().BeFalse();
+        result.Errors.Should().Contain(e => e.PropertyName == nameof(request.Street));
+    }
+
+    [Fact]
+    public void Validate_EmptyCity_IsInvalid()
+    {
+        // Arrange
+        var request = ValidRequest();
+        request.City = string.Empty;
+
+        // Act
+        var result = _validator.Validate(request);
+
+        // Assert
+        result.IsValid.Should().BeFalse();
+        result.Errors.Should().Contain(e => e.PropertyName == nameof(request.City));
+    }
+
+    [Fact]
+    public void Validate_EmptyState_IsInvalid()
+    {
+        // Arrange
+        var request = ValidRequest();
+        request.State = string.Empty;
+
+        // Act
+        var result = _validator.Validate(request);
+
+        // Assert
+        result.IsValid.Should().BeFalse();
+        result.Errors.Should().Contain(e => e.PropertyName == nameof(request.State));
+    }
+
+    [Theory]
+    [InlineData("notanemail")]
+    [InlineData("@nodomain.com")]
+    [InlineData("trailing.dot@example.com.")]
+    [InlineData("")]
+    public void Validate_InvalidEmail_IsInvalid(string email)
+    {
+        // Arrange
+        var request = ValidRequest();
+        request.Email = email;
+
+        // Act
+        var result = _validator.Validate(request);
+
+        // Assert
+        result.IsValid.Should().BeFalse();
+        result.Errors.Should().Contain(e => e.PropertyName == nameof(request.Email));
+    }
+
+    [Fact]
+    public void Validate_EmptyPhone_IsInvalid()
+    {
+        // Arrange
+        var request = ValidRequest();
+        request.Phone = string.Empty;
+
+        // Act
+        var result = _validator.Validate(request);
+
+        // Assert
+        result.IsValid.Should().BeFalse();
+        result.Errors.Should().Contain(e => e.PropertyName == nameof(request.Phone));
+    }
+
+    [Fact]
+    public void Validate_EmptyInvoiceName_IsInvalid()
+    {
+        // Arrange
+        var request = ValidRequest();
+        request.InvoiceName = string.Empty;
+
+        // Act
+        var result = _validator.Validate(request);
+
+        // Assert
+        result.IsValid.Should().BeFalse();
+        result.Errors.Should().Contain(e => e.PropertyName == nameof(request.InvoiceName));
+    }
+}

--- a/tests/xUnitTests/Validators/Customer/CustomerUpdateValidatorTest.cs
+++ b/tests/xUnitTests/Validators/Customer/CustomerUpdateValidatorTest.cs
@@ -1,0 +1,194 @@
+using Contracts.Requests.Customer;
+using FluentAssertions;
+using FluentValidation;
+
+namespace xUnitTests.Validators.Customer;
+
+public class CustomerUpdateValidatorTest
+{
+    private readonly CustomerUpdateValidator _validator = new();
+
+    private static CustomerUpdateRequest ValidRequest() => new()
+    {
+        Id = Guid.NewGuid(),
+        CompanyNumber = "123456",
+        CompanyName = "Test Company",
+        Street = "Test Street 1",
+        City = "Test City",
+        State = "Test State",
+        Email = "test@example.com",
+        Phone = "1234567890",
+        InvoiceName = "Test Invoice Name",
+        InvoiceNumber = 1
+    };
+
+    [Fact]
+    public void Validate_ValidRequest_IsValid()
+    {
+        // Arrange
+        var request = ValidRequest();
+
+        // Act
+        var result = _validator.Validate(request);
+
+        // Assert
+        result.IsValid.Should().BeTrue();
+    }
+
+    [Fact]
+    public void Validate_EmptyId_IsInvalid()
+    {
+        // Arrange
+        var request = ValidRequest();
+        request.Id = Guid.Empty;
+
+        // Act
+        var result = _validator.Validate(request);
+
+        // Assert
+        result.IsValid.Should().BeFalse();
+        result.Errors.Should().Contain(e => e.PropertyName == nameof(request.Id));
+    }
+
+    [Fact]
+    public void Validate_EmptyCompanyNumber_IsInvalid()
+    {
+        // Arrange
+        var request = ValidRequest();
+        request.CompanyNumber = string.Empty;
+
+        // Act
+        var result = _validator.Validate(request);
+
+        // Assert
+        result.IsValid.Should().BeFalse();
+        result.Errors.Should().Contain(e => e.PropertyName == nameof(request.CompanyNumber));
+    }
+
+    [Fact]
+    public void Validate_EmptyCompanyName_IsInvalid()
+    {
+        // Arrange
+        var request = ValidRequest();
+        request.CompanyName = string.Empty;
+
+        // Act
+        var result = _validator.Validate(request);
+
+        // Assert
+        result.IsValid.Should().BeFalse();
+        result.Errors.Should().Contain(e => e.PropertyName == nameof(request.CompanyName));
+    }
+
+    [Fact]
+    public void Validate_EmptyStreet_IsInvalid()
+    {
+        // Arrange
+        var request = ValidRequest();
+        request.Street = string.Empty;
+
+        // Act
+        var result = _validator.Validate(request);
+
+        // Assert
+        result.IsValid.Should().BeFalse();
+        result.Errors.Should().Contain(e => e.PropertyName == nameof(request.Street));
+    }
+
+    [Fact]
+    public void Validate_EmptyCity_IsInvalid()
+    {
+        // Arrange
+        var request = ValidRequest();
+        request.City = string.Empty;
+
+        // Act
+        var result = _validator.Validate(request);
+
+        // Assert
+        result.IsValid.Should().BeFalse();
+        result.Errors.Should().Contain(e => e.PropertyName == nameof(request.City));
+    }
+
+    [Fact]
+    public void Validate_EmptyState_IsInvalid()
+    {
+        // Arrange
+        var request = ValidRequest();
+        request.State = string.Empty;
+
+        // Act
+        var result = _validator.Validate(request);
+
+        // Assert
+        result.IsValid.Should().BeFalse();
+        result.Errors.Should().Contain(e => e.PropertyName == nameof(request.State));
+    }
+
+    [Theory]
+    [InlineData("notanemail")]
+    [InlineData("@nodomain.com")]
+    [InlineData("trailing.dot@example.com.")]
+    [InlineData("")]
+    public void Validate_InvalidEmail_IsInvalid(string email)
+    {
+        // Arrange
+        var request = ValidRequest();
+        request.Email = email;
+
+        // Act
+        var result = _validator.Validate(request);
+
+        // Assert
+        result.IsValid.Should().BeFalse();
+        result.Errors.Should().Contain(e => e.PropertyName == nameof(request.Email));
+    }
+
+    [Fact]
+    public void Validate_EmptyPhone_IsInvalid()
+    {
+        // Arrange
+        var request = ValidRequest();
+        request.Phone = string.Empty;
+
+        // Act
+        var result = _validator.Validate(request);
+
+        // Assert
+        result.IsValid.Should().BeFalse();
+        result.Errors.Should().Contain(e => e.PropertyName == nameof(request.Phone));
+    }
+
+    [Fact]
+    public void Validate_EmptyInvoiceName_IsInvalid()
+    {
+        // Arrange
+        var request = ValidRequest();
+        request.InvoiceName = string.Empty;
+
+        // Act
+        var result = _validator.Validate(request);
+
+        // Assert
+        result.IsValid.Should().BeFalse();
+        result.Errors.Should().Contain(e => e.PropertyName == nameof(request.InvoiceName));
+    }
+
+    [Theory]
+    [InlineData(0)]
+    [InlineData(-1)]
+    [InlineData(-100)]
+    public void Validate_InvoiceNumberNotGreaterThanZero_IsInvalid(int invoiceNumber)
+    {
+        // Arrange
+        var request = ValidRequest();
+        request.InvoiceNumber = invoiceNumber;
+
+        // Act
+        var result = _validator.Validate(request);
+
+        // Assert
+        result.IsValid.Should().BeFalse();
+        result.Errors.Should().Contain(e => e.PropertyName == nameof(request.InvoiceNumber));
+    }
+}

--- a/tests/xUnitTests/Validators/Invoice/InvoiceAddValidatorTest.cs
+++ b/tests/xUnitTests/Validators/Invoice/InvoiceAddValidatorTest.cs
@@ -1,0 +1,161 @@
+using Contracts.Requests.Invoice;
+using FluentAssertions;
+using FluentValidation;
+using Validators.Invoice;
+
+namespace xUnitTests.Validators.Invoice;
+
+public class InvoiceAddValidatorTest
+{
+    private readonly InvoiceAddValidator _validator = new();
+
+    private static InvoiceAddRequest ValidRequest() => new()
+    {
+        UserId = Guid.NewGuid(),
+        SellerId = Guid.NewGuid(),
+        CustomerId = Guid.NewGuid(),
+        Items =
+        [
+            new InvoiceItemRequest { Id = Guid.NewGuid(), Quantity = 2 }
+        ],
+        CreatedDate = new DateOnly(2024, 1, 1),
+        DueDate = new DateOnly(2024, 1, 31)
+    };
+
+    [Fact]
+    public void Validate_ValidRequest_IsValid()
+    {
+        // Arrange
+        var request = ValidRequest();
+
+        // Act
+        var result = _validator.Validate(request);
+
+        // Assert
+        result.IsValid.Should().BeTrue();
+    }
+
+    [Fact]
+    public void Validate_EmptyUserId_IsInvalid()
+    {
+        // Arrange
+        var request = ValidRequest();
+        request.UserId = Guid.Empty;
+
+        // Act
+        var result = _validator.Validate(request);
+
+        // Assert
+        result.IsValid.Should().BeFalse();
+        result.Errors.Should().Contain(e => e.PropertyName == nameof(request.UserId));
+    }
+
+    [Fact]
+    public void Validate_EmptySellerId_IsInvalid()
+    {
+        // Arrange
+        var request = ValidRequest();
+        request.SellerId = Guid.Empty;
+
+        // Act
+        var result = _validator.Validate(request);
+
+        // Assert
+        result.IsValid.Should().BeFalse();
+        result.Errors.Should().Contain(e => e.PropertyName == nameof(request.SellerId));
+    }
+
+    [Fact]
+    public void Validate_EmptyCustomerId_IsInvalid()
+    {
+        // Arrange
+        var request = ValidRequest();
+        request.CustomerId = Guid.Empty;
+
+        // Act
+        var result = _validator.Validate(request);
+
+        // Assert
+        result.IsValid.Should().BeFalse();
+        result.Errors.Should().Contain(e => e.PropertyName == nameof(request.CustomerId));
+    }
+
+    [Fact]
+    public void Validate_EmptyItems_IsInvalid()
+    {
+        // Arrange
+        var request = ValidRequest();
+        request.Items = [];
+
+        // Act
+        var result = _validator.Validate(request);
+
+        // Assert
+        result.IsValid.Should().BeFalse();
+        result.Errors.Should().Contain(e => e.PropertyName == nameof(request.Items));
+    }
+
+    [Fact]
+    public void Validate_DueDateBeforeCreatedDate_IsInvalid()
+    {
+        // Arrange
+        var request = ValidRequest();
+        request.CreatedDate = new DateOnly(2024, 1, 31);
+        request.DueDate = new DateOnly(2024, 1, 1);
+
+        // Act
+        var result = _validator.Validate(request);
+
+        // Assert
+        result.IsValid.Should().BeFalse();
+        result.Errors.Should().Contain(e => e.PropertyName == nameof(request.DueDate));
+    }
+
+    [Fact]
+    public void Validate_DueDateEqualToCreatedDate_IsValid()
+    {
+        // Arrange
+        var request = ValidRequest();
+        request.CreatedDate = new DateOnly(2024, 1, 1);
+        request.DueDate = new DateOnly(2024, 1, 1);
+
+        // Act
+        var result = _validator.Validate(request);
+
+        // Assert
+        result.IsValid.Should().BeTrue();
+    }
+
+    [Fact]
+    public void Validate_ItemWithEmptyId_ThrowsValidationException()
+    {
+        // Arrange
+        var request = ValidRequest();
+        request.Items = [new InvoiceItemRequest { Id = Guid.Empty, Quantity = 1 }];
+
+        // Act & Assert
+        Assert.Throws<ValidationException>(() => _validator.Validate(request));
+    }
+
+    [Fact]
+    public void Validate_ItemWithZeroQuantity_ThrowsValidationException()
+    {
+        // Arrange
+        var request = ValidRequest();
+        request.Items = [new InvoiceItemRequest { Id = Guid.NewGuid(), Quantity = 0 }];
+
+        // Act & Assert
+        Assert.Throws<ValidationException>(() => _validator.Validate(request));
+    }
+
+    [Fact]
+    public void Validate_ItemWithNegativeQuantity_ThrowsValidationException()
+    {
+        // Arrange
+        var request = ValidRequest();
+        request.Items = [new InvoiceItemRequest { Id = Guid.NewGuid(), Quantity = -1 }];
+
+        // Act & Assert
+        Assert.Throws<ValidationException>(() => _validator.Validate(request));
+    }
+}

--- a/tests/xUnitTests/Validators/Invoice/InvoiceGenerateValidatorTest.cs
+++ b/tests/xUnitTests/Validators/Invoice/InvoiceGenerateValidatorTest.cs
@@ -1,0 +1,37 @@
+using Contracts.Requests.Invoice;
+using FluentAssertions;
+using Validators.Invoice;
+
+namespace xUnitTests.Validators.Invoice;
+
+public class InvoiceGenerateValidatorTest
+{
+    private readonly InvoiceGenerateValidator _validator = new();
+
+    [Fact]
+    public void Validate_ValidRequest_IsValid()
+    {
+        // Arrange
+        var request = new InvoiceGenerateRequest { Id = Guid.NewGuid() };
+
+        // Act
+        var result = _validator.Validate(request);
+
+        // Assert
+        result.IsValid.Should().BeTrue();
+    }
+
+    [Fact]
+    public void Validate_EmptyId_IsInvalid()
+    {
+        // Arrange
+        var request = new InvoiceGenerateRequest { Id = Guid.Empty };
+
+        // Act
+        var result = _validator.Validate(request);
+
+        // Assert
+        result.IsValid.Should().BeFalse();
+        result.Errors.Should().Contain(e => e.PropertyName == nameof(request.Id));
+    }
+}

--- a/tests/xUnitTests/Validators/Invoice/InvoiceItemUpdateValidatorTest.cs
+++ b/tests/xUnitTests/Validators/Invoice/InvoiceItemUpdateValidatorTest.cs
@@ -1,0 +1,97 @@
+using Contracts.Requests.Invoice;
+using FluentAssertions;
+using Validators.Invoice;
+
+namespace xUnitTests.Validators.Invoice;
+
+public class InvoiceItemUpdateValidatorTest
+{
+    private readonly InvoiceItemUpdateValidator _validator = new();
+
+    private static InvoiceItemUpdateRequest ValidRequest() => new()
+    {
+        Id = Guid.NewGuid(),
+        Name = "Test Item",
+        Quantity = 2,
+        Price = 9.99m
+    };
+
+    [Fact]
+    public void Validate_ValidRequest_IsValid()
+    {
+        // Arrange
+        var request = ValidRequest();
+
+        // Act
+        var result = _validator.Validate(request);
+
+        // Assert
+        result.IsValid.Should().BeTrue();
+    }
+
+    [Fact]
+    public void Validate_EmptyId_IsInvalid()
+    {
+        // Arrange
+        var request = ValidRequest();
+        request.Id = Guid.Empty;
+
+        // Act
+        var result = _validator.Validate(request);
+
+        // Assert
+        result.IsValid.Should().BeFalse();
+        result.Errors.Should().Contain(e => e.PropertyName == nameof(request.Id));
+    }
+
+    [Fact]
+    public void Validate_EmptyName_IsInvalid()
+    {
+        // Arrange
+        var request = ValidRequest();
+        request.Name = string.Empty;
+
+        // Act
+        var result = _validator.Validate(request);
+
+        // Assert
+        result.IsValid.Should().BeFalse();
+        result.Errors.Should().Contain(e => e.PropertyName == nameof(request.Name));
+    }
+
+    [Theory]
+    [InlineData(0)]
+    [InlineData(-1)]
+    [InlineData(-100)]
+    public void Validate_QuantityNotGreaterThanZero_IsInvalid(decimal quantity)
+    {
+        // Arrange
+        var request = ValidRequest();
+        request.Quantity = quantity;
+
+        // Act
+        var result = _validator.Validate(request);
+
+        // Assert
+        result.IsValid.Should().BeFalse();
+        result.Errors.Should().Contain(e => e.PropertyName == nameof(request.Quantity));
+    }
+
+    [Theory]
+    [InlineData(0)]
+    [InlineData(-1)]
+    [InlineData(-100)]
+    public void Validate_PriceNotGreaterThanZero_IsInvalid(decimal price)
+    {
+        // Arrange
+        var request = ValidRequest();
+        request.Price = price;
+
+        // Act
+        var result = _validator.Validate(request);
+
+        // Assert
+        result.IsValid.Should().BeFalse();
+        result.Errors.Should().Contain(e => e.PropertyName == nameof(request.Price));
+    }
+}

--- a/tests/xUnitTests/Validators/Invoice/InvoiceItemValidatorTest.cs
+++ b/tests/xUnitTests/Validators/Invoice/InvoiceItemValidatorTest.cs
@@ -1,0 +1,70 @@
+using Contracts.Requests.Invoice;
+using FluentAssertions;
+using Validators.Invoice;
+
+namespace xUnitTests.Validators.Invoice;
+
+public class InvoiceItemValidatorTest
+{
+    private readonly InvoiceItemValidator _validator = new();
+
+    [Fact]
+    public void Validate_ValidRequest_IsValid()
+    {
+        // Arrange
+        var request = new InvoiceItemRequest { Id = Guid.NewGuid(), Quantity = 2 };
+
+        // Act
+        var result = _validator.Validate(request);
+
+        // Assert
+        result.IsValid.Should().BeTrue();
+    }
+
+    [Fact]
+    public void Validate_EmptyId_IsInvalid()
+    {
+        // Arrange
+        var request = new InvoiceItemRequest { Id = Guid.Empty, Quantity = 1 };
+
+        // Act
+        var result = _validator.Validate(request);
+
+        // Assert
+        result.IsValid.Should().BeFalse();
+        result.Errors.Should().Contain(e => e.PropertyName == nameof(request.Id));
+    }
+
+    [Theory]
+    [InlineData(0)]
+    [InlineData(-1)]
+    [InlineData(-10)]
+    public void Validate_QuantityNotGreaterThanZero_IsInvalid(decimal quantity)
+    {
+        // Arrange
+        var request = new InvoiceItemRequest { Id = Guid.NewGuid(), Quantity = quantity };
+
+        // Act
+        var result = _validator.Validate(request);
+
+        // Assert
+        result.IsValid.Should().BeFalse();
+        result.Errors.Should().Contain(e => e.PropertyName == nameof(request.Quantity));
+    }
+
+    [Theory]
+    [InlineData(1)]
+    [InlineData(0.5)]
+    [InlineData(100)]
+    public void Validate_ValidQuantity_IsValid(decimal quantity)
+    {
+        // Arrange
+        var request = new InvoiceItemRequest { Id = Guid.NewGuid(), Quantity = quantity };
+
+        // Act
+        var result = _validator.Validate(request);
+
+        // Assert
+        result.IsValid.Should().BeTrue();
+    }
+}

--- a/tests/xUnitTests/Validators/Invoice/InvoiceUpdateValidatorTest.cs
+++ b/tests/xUnitTests/Validators/Invoice/InvoiceUpdateValidatorTest.cs
@@ -1,0 +1,164 @@
+using Contracts.Requests.Customer;
+using Contracts.Requests.Invoice;
+using Contracts.Requests.Seller;
+using FluentAssertions;
+using FluentValidation;
+using Validators.Invoice;
+
+namespace xUnitTests.Validators.Invoice;
+
+public class InvoiceUpdateValidatorTest
+{
+    private readonly InvoiceUpdateValidator _validator = new();
+
+    private static SellerUpdateRequest ValidSeller() => new()
+    {
+        Id = Guid.NewGuid(),
+        CompanyNumber = "123456",
+        CompanyName = "Seller Company",
+        Street = "Seller Street",
+        City = "Seller City",
+        State = "Seller State",
+        Email = "seller@example.com",
+        Phone = "1234567890",
+        BankName = "Test Bank",
+        BankNumber = "LT123456789"
+    };
+
+    private static CustomerUpdateRequest ValidCustomer() => new()
+    {
+        Id = Guid.NewGuid(),
+        CompanyNumber = "654321",
+        CompanyName = "Customer Company",
+        Street = "Customer Street",
+        City = "Customer City",
+        State = "Customer State",
+        Email = "customer@example.com",
+        Phone = "0987654321",
+        InvoiceName = "Customer Invoice",
+        InvoiceNumber = 1
+    };
+
+    private static InvoiceUpdateRequest ValidRequest() => new()
+    {
+        Id = Guid.NewGuid(),
+        InvoiceNumber = 1,
+        Seller = ValidSeller(),
+        Customer = ValidCustomer(),
+        Items =
+        [
+            new InvoiceItemUpdateRequest { Id = Guid.NewGuid(), Name = "Item 1", Quantity = 2, Price = 10m }
+        ],
+        CreatedDate = new DateOnly(2024, 1, 1),
+        DueDate = new DateOnly(2024, 1, 31)
+    };
+
+    [Fact]
+    public void Validate_ValidRequest_IsValid()
+    {
+        // Arrange
+        var request = ValidRequest();
+
+        // Act
+        var result = _validator.Validate(request);
+
+        // Assert
+        result.IsValid.Should().BeTrue();
+    }
+
+    [Fact]
+    public void Validate_EmptyId_IsInvalid()
+    {
+        // Arrange
+        var request = ValidRequest();
+        request.Id = Guid.Empty;
+
+        // Act
+        var result = _validator.Validate(request);
+
+        // Assert
+        result.IsValid.Should().BeFalse();
+        result.Errors.Should().Contain(e => e.PropertyName == nameof(request.Id));
+    }
+
+    [Fact]
+    public void Validate_EmptyItems_IsInvalid()
+    {
+        // Arrange
+        var request = ValidRequest();
+        request.Items = [];
+
+        // Act
+        var result = _validator.Validate(request);
+
+        // Assert
+        result.IsValid.Should().BeFalse();
+        result.Errors.Should().Contain(e => e.PropertyName == nameof(request.Items));
+    }
+
+    [Fact]
+    public void Validate_DueDateBeforeCreatedDate_IsInvalid()
+    {
+        // Arrange
+        var request = ValidRequest();
+        request.CreatedDate = new DateOnly(2024, 1, 31);
+        request.DueDate = new DateOnly(2024, 1, 1);
+
+        // Act
+        var result = _validator.Validate(request);
+
+        // Assert
+        result.IsValid.Should().BeFalse();
+        result.Errors.Should().Contain(e => e.PropertyName == nameof(request.DueDate));
+    }
+
+    [Theory]
+    [InlineData(0)]
+    [InlineData(-1)]
+    public void Validate_InvoiceNumberNotGreaterThanZero_IsInvalid(int invoiceNumber)
+    {
+        // Arrange
+        var request = ValidRequest();
+        request.InvoiceNumber = invoiceNumber;
+
+        // Act
+        var result = _validator.Validate(request);
+
+        // Assert
+        result.IsValid.Should().BeFalse();
+        result.Errors.Should().Contain(e => e.PropertyName == nameof(request.InvoiceNumber));
+    }
+
+    [Fact]
+    public void Validate_InvalidSellerEmail_ThrowsValidationException()
+    {
+        // Arrange
+        var request = ValidRequest();
+        request.Seller.Email = "not-an-email";
+
+        // Act & Assert
+        Assert.Throws<ValidationException>(() => _validator.Validate(request));
+    }
+
+    [Fact]
+    public void Validate_InvalidCustomerInvoiceNumber_ThrowsValidationException()
+    {
+        // Arrange
+        var request = ValidRequest();
+        request.Customer.InvoiceNumber = 0;
+
+        // Act & Assert
+        Assert.Throws<ValidationException>(() => _validator.Validate(request));
+    }
+
+    [Fact]
+    public void Validate_ItemWithEmptyName_ThrowsValidationException()
+    {
+        // Arrange
+        var request = ValidRequest();
+        request.Items = [new InvoiceItemUpdateRequest { Id = Guid.NewGuid(), Name = string.Empty, Quantity = 1, Price = 10m }];
+
+        // Act & Assert
+        Assert.Throws<ValidationException>(() => _validator.Validate(request));
+    }
+}

--- a/tests/xUnitTests/Validators/Item/ItemAddValidatorTest.cs
+++ b/tests/xUnitTests/Validators/Item/ItemAddValidatorTest.cs
@@ -1,0 +1,129 @@
+using Contracts.Requests.Item;
+using FluentAssertions;
+using Validators.Item;
+
+namespace xUnitTests.Validators.Item;
+
+public class ItemAddValidatorTest
+{
+    private readonly ItemAddValidator _validator = new();
+
+    private static ItemAddRequest ValidRequest() => new()
+    {
+        CustomerId = Guid.NewGuid(),
+        Name = "Test Item",
+        Price = 9.99m,
+        Quantity = 10
+    };
+
+    [Fact]
+    public void Validate_ValidRequest_IsValid()
+    {
+        // Arrange
+        var request = ValidRequest();
+
+        // Act
+        var result = _validator.Validate(request);
+
+        // Assert
+        result.IsValid.Should().BeTrue();
+    }
+
+    [Fact]
+    public void Validate_EmptyCustomerId_IsInvalid()
+    {
+        // Arrange
+        var request = ValidRequest();
+        request.CustomerId = Guid.Empty;
+
+        // Act
+        var result = _validator.Validate(request);
+
+        // Assert
+        result.IsValid.Should().BeFalse();
+        result.Errors.Should().Contain(e => e.PropertyName == nameof(request.CustomerId));
+    }
+
+    [Fact]
+    public void Validate_EmptyName_IsInvalid()
+    {
+        // Arrange
+        var request = ValidRequest();
+        request.Name = string.Empty;
+
+        // Act
+        var result = _validator.Validate(request);
+
+        // Assert
+        result.IsValid.Should().BeFalse();
+        result.Errors.Should().Contain(e => e.PropertyName == nameof(request.Name));
+    }
+
+    [Theory]
+    [InlineData(0)]
+    [InlineData(-0.01)]
+    [InlineData(-100)]
+    public void Validate_PriceNotGreaterThanZero_IsInvalid(double price)
+    {
+        // Arrange
+        var request = ValidRequest();
+        request.Price = (decimal)price;
+
+        // Act
+        var result = _validator.Validate(request);
+
+        // Assert
+        result.IsValid.Should().BeFalse();
+        result.Errors.Should().Contain(e => e.PropertyName == nameof(request.Price));
+    }
+
+    [Fact]
+    public void Validate_ZeroQuantity_IsInvalid()
+    {
+        // Arrange
+        var request = ValidRequest();
+        request.Quantity = 0;
+
+        // Act
+        var result = _validator.Validate(request);
+
+        // Assert
+        result.IsValid.Should().BeFalse();
+        result.Errors.Should().Contain(e => e.PropertyName == nameof(request.Quantity));
+    }
+
+    [Theory]
+    [InlineData(-1)]
+    [InlineData(-2)]
+    [InlineData(-100)]
+    public void Validate_NegativeQuantity_IsInvalid(decimal quantity)
+    {
+        // Arrange
+        var request = ValidRequest();
+        request.Quantity = quantity;
+
+        // Act
+        var result = _validator.Validate(request);
+
+        // Assert
+        result.IsValid.Should().BeFalse();
+        result.Errors.Should().Contain(e => e.PropertyName == nameof(request.Quantity));
+    }
+
+    [Theory]
+    [InlineData(1)]
+    [InlineData(10)]
+    [InlineData(100)]
+    public void Validate_ValidQuantity_IsValid(decimal quantity)
+    {
+        // Arrange
+        var request = ValidRequest();
+        request.Quantity = quantity;
+
+        // Act
+        var result = _validator.Validate(request);
+
+        // Assert
+        result.IsValid.Should().BeTrue();
+    }
+}

--- a/tests/xUnitTests/Validators/Item/ItemUpdateValidatorTest.cs
+++ b/tests/xUnitTests/Validators/Item/ItemUpdateValidatorTest.cs
@@ -1,0 +1,112 @@
+using Contracts.Requests.Item;
+using FluentAssertions;
+using Validators.Item;
+
+namespace xUnitTests.Validators.Item;
+
+public class ItemUpdateValidatorTest
+{
+    private readonly ItemUpdateValidator _validator = new();
+
+    private static ItemUpdateRequest ValidRequest() => new()
+    {
+        Id = Guid.NewGuid(),
+        Name = "Test Item",
+        Price = 9.99m,
+        Quantity = 10
+    };
+
+    [Fact]
+    public void Validate_ValidRequest_IsValid()
+    {
+        // Arrange
+        var request = ValidRequest();
+
+        // Act
+        var result = _validator.Validate(request);
+
+        // Assert
+        result.IsValid.Should().BeTrue();
+    }
+
+    [Fact]
+    public void Validate_EmptyId_IsInvalid()
+    {
+        // Arrange
+        var request = ValidRequest();
+        request.Id = Guid.Empty;
+
+        // Act
+        var result = _validator.Validate(request);
+
+        // Assert
+        result.IsValid.Should().BeFalse();
+        result.Errors.Should().Contain(e => e.PropertyName == nameof(request.Id));
+    }
+
+    [Fact]
+    public void Validate_EmptyName_IsInvalid()
+    {
+        // Arrange
+        var request = ValidRequest();
+        request.Name = string.Empty;
+
+        // Act
+        var result = _validator.Validate(request);
+
+        // Assert
+        result.IsValid.Should().BeFalse();
+        result.Errors.Should().Contain(e => e.PropertyName == nameof(request.Name));
+    }
+
+    [Theory]
+    [InlineData(0)]
+    [InlineData(-0.01)]
+    [InlineData(-100)]
+    public void Validate_PriceNotGreaterThanZero_IsInvalid(double price)
+    {
+        // Arrange
+        var request = ValidRequest();
+        request.Price = (decimal)price;
+
+        // Act
+        var result = _validator.Validate(request);
+
+        // Assert
+        result.IsValid.Should().BeFalse();
+        result.Errors.Should().Contain(e => e.PropertyName == nameof(request.Price));
+    }
+
+    [Fact]
+    public void Validate_ZeroQuantity_IsInvalid()
+    {
+        // Arrange
+        var request = ValidRequest();
+        request.Quantity = 0;
+
+        // Act
+        var result = _validator.Validate(request);
+
+        // Assert
+        result.IsValid.Should().BeFalse();
+        result.Errors.Should().Contain(e => e.PropertyName == nameof(request.Quantity));
+    }
+
+    [Theory]
+    [InlineData(-1)]
+    [InlineData(-2)]
+    [InlineData(-100)]
+    public void Validate_NegativeQuantity_IsInvalid(decimal quantity)
+    {
+        // Arrange
+        var request = ValidRequest();
+        request.Quantity = quantity;
+
+        // Act
+        var result = _validator.Validate(request);
+
+        // Assert
+        result.IsValid.Should().BeFalse();
+        result.Errors.Should().Contain(e => e.PropertyName == nameof(request.Quantity));
+    }
+}

--- a/tests/xUnitTests/Validators/Seller/SellerAddValidatorTest.cs
+++ b/tests/xUnitTests/Validators/Seller/SellerAddValidatorTest.cs
@@ -1,0 +1,191 @@
+using Contracts.Requests.Seller;
+using FluentAssertions;
+using Validators.Seller;
+
+namespace xUnitTests.Validators.Seller;
+
+public class SellerAddValidatorTest
+{
+    private readonly SellerAddValidator _validator = new();
+
+    private static SellerAddRequest ValidRequest() => new()
+    {
+        UserId = Guid.NewGuid(),
+        CompanyNumber = "123456",
+        CompanyName = "Test Company",
+        Street = "Test Street 1",
+        City = "Test City",
+        State = "Test State",
+        Email = "test@example.com",
+        Phone = "1234567890",
+        BankName = "Test Bank",
+        BankNumber = "LT123456789"
+    };
+
+    [Fact]
+    public void Validate_ValidRequest_IsValid()
+    {
+        // Arrange
+        var request = ValidRequest();
+
+        // Act
+        var result = _validator.Validate(request);
+
+        // Assert
+        result.IsValid.Should().BeTrue();
+    }
+
+    [Fact]
+    public void Validate_EmptyUserId_IsInvalid()
+    {
+        // Arrange
+        var request = ValidRequest();
+        request.UserId = Guid.Empty;
+
+        // Act
+        var result = _validator.Validate(request);
+
+        // Assert
+        result.IsValid.Should().BeFalse();
+        result.Errors.Should().Contain(e => e.PropertyName == nameof(request.UserId));
+    }
+
+    [Fact]
+    public void Validate_EmptyCompanyNumber_IsInvalid()
+    {
+        // Arrange
+        var request = ValidRequest();
+        request.CompanyNumber = string.Empty;
+
+        // Act
+        var result = _validator.Validate(request);
+
+        // Assert
+        result.IsValid.Should().BeFalse();
+        result.Errors.Should().Contain(e => e.PropertyName == nameof(request.CompanyNumber));
+    }
+
+    [Fact]
+    public void Validate_EmptyCompanyName_IsInvalid()
+    {
+        // Arrange
+        var request = ValidRequest();
+        request.CompanyName = string.Empty;
+
+        // Act
+        var result = _validator.Validate(request);
+
+        // Assert
+        result.IsValid.Should().BeFalse();
+        result.Errors.Should().Contain(e => e.PropertyName == nameof(request.CompanyName));
+    }
+
+    [Fact]
+    public void Validate_EmptyStreet_IsInvalid()
+    {
+        // Arrange
+        var request = ValidRequest();
+        request.Street = string.Empty;
+
+        // Act
+        var result = _validator.Validate(request);
+
+        // Assert
+        result.IsValid.Should().BeFalse();
+        result.Errors.Should().Contain(e => e.PropertyName == nameof(request.Street));
+    }
+
+    [Fact]
+    public void Validate_EmptyCity_IsInvalid()
+    {
+        // Arrange
+        var request = ValidRequest();
+        request.City = string.Empty;
+
+        // Act
+        var result = _validator.Validate(request);
+
+        // Assert
+        result.IsValid.Should().BeFalse();
+        result.Errors.Should().Contain(e => e.PropertyName == nameof(request.City));
+    }
+
+    [Fact]
+    public void Validate_EmptyState_IsInvalid()
+    {
+        // Arrange
+        var request = ValidRequest();
+        request.State = string.Empty;
+
+        // Act
+        var result = _validator.Validate(request);
+
+        // Assert
+        result.IsValid.Should().BeFalse();
+        result.Errors.Should().Contain(e => e.PropertyName == nameof(request.State));
+    }
+
+    [Theory]
+    [InlineData("notanemail")]
+    [InlineData("@nodomain.com")]
+    [InlineData("trailing.dot@example.com.")]
+    [InlineData("")]
+    public void Validate_InvalidEmail_IsInvalid(string email)
+    {
+        // Arrange
+        var request = ValidRequest();
+        request.Email = email;
+
+        // Act
+        var result = _validator.Validate(request);
+
+        // Assert
+        result.IsValid.Should().BeFalse();
+        result.Errors.Should().Contain(e => e.PropertyName == nameof(request.Email));
+    }
+
+    [Fact]
+    public void Validate_EmptyPhone_IsInvalid()
+    {
+        // Arrange
+        var request = ValidRequest();
+        request.Phone = string.Empty;
+
+        // Act
+        var result = _validator.Validate(request);
+
+        // Assert
+        result.IsValid.Should().BeFalse();
+        result.Errors.Should().Contain(e => e.PropertyName == nameof(request.Phone));
+    }
+
+    [Fact]
+    public void Validate_EmptyBankName_IsInvalid()
+    {
+        // Arrange
+        var request = ValidRequest();
+        request.BankName = string.Empty;
+
+        // Act
+        var result = _validator.Validate(request);
+
+        // Assert
+        result.IsValid.Should().BeFalse();
+        result.Errors.Should().Contain(e => e.PropertyName == nameof(request.BankName));
+    }
+
+    [Fact]
+    public void Validate_EmptyBankNumber_IsInvalid()
+    {
+        // Arrange
+        var request = ValidRequest();
+        request.BankNumber = string.Empty;
+
+        // Act
+        var result = _validator.Validate(request);
+
+        // Assert
+        result.IsValid.Should().BeFalse();
+        result.Errors.Should().Contain(e => e.PropertyName == nameof(request.BankNumber));
+    }
+}

--- a/tests/xUnitTests/Validators/Seller/SellerUpdateValidatorTest.cs
+++ b/tests/xUnitTests/Validators/Seller/SellerUpdateValidatorTest.cs
@@ -1,0 +1,191 @@
+using Contracts.Requests.Seller;
+using FluentAssertions;
+using Validators.Seller;
+
+namespace xUnitTests.Validators.Seller;
+
+public class SellerUpdateValidatorTest
+{
+    private readonly SellerUpdateValidator _validator = new();
+
+    private static SellerUpdateRequest ValidRequest() => new()
+    {
+        Id = Guid.NewGuid(),
+        CompanyNumber = "123456",
+        CompanyName = "Test Company",
+        Street = "Test Street 1",
+        City = "Test City",
+        State = "Test State",
+        Email = "test@example.com",
+        Phone = "1234567890",
+        BankName = "Test Bank",
+        BankNumber = "LT123456789"
+    };
+
+    [Fact]
+    public void Validate_ValidRequest_IsValid()
+    {
+        // Arrange
+        var request = ValidRequest();
+
+        // Act
+        var result = _validator.Validate(request);
+
+        // Assert
+        result.IsValid.Should().BeTrue();
+    }
+
+    [Fact]
+    public void Validate_EmptyId_IsInvalid()
+    {
+        // Arrange
+        var request = ValidRequest();
+        request.Id = Guid.Empty;
+
+        // Act
+        var result = _validator.Validate(request);
+
+        // Assert
+        result.IsValid.Should().BeFalse();
+        result.Errors.Should().Contain(e => e.PropertyName == nameof(request.Id));
+    }
+
+    [Fact]
+    public void Validate_EmptyCompanyNumber_IsInvalid()
+    {
+        // Arrange
+        var request = ValidRequest();
+        request.CompanyNumber = string.Empty;
+
+        // Act
+        var result = _validator.Validate(request);
+
+        // Assert
+        result.IsValid.Should().BeFalse();
+        result.Errors.Should().Contain(e => e.PropertyName == nameof(request.CompanyNumber));
+    }
+
+    [Fact]
+    public void Validate_EmptyCompanyName_IsInvalid()
+    {
+        // Arrange
+        var request = ValidRequest();
+        request.CompanyName = string.Empty;
+
+        // Act
+        var result = _validator.Validate(request);
+
+        // Assert
+        result.IsValid.Should().BeFalse();
+        result.Errors.Should().Contain(e => e.PropertyName == nameof(request.CompanyName));
+    }
+
+    [Fact]
+    public void Validate_EmptyStreet_IsInvalid()
+    {
+        // Arrange
+        var request = ValidRequest();
+        request.Street = string.Empty;
+
+        // Act
+        var result = _validator.Validate(request);
+
+        // Assert
+        result.IsValid.Should().BeFalse();
+        result.Errors.Should().Contain(e => e.PropertyName == nameof(request.Street));
+    }
+
+    [Fact]
+    public void Validate_EmptyCity_IsInvalid()
+    {
+        // Arrange
+        var request = ValidRequest();
+        request.City = string.Empty;
+
+        // Act
+        var result = _validator.Validate(request);
+
+        // Assert
+        result.IsValid.Should().BeFalse();
+        result.Errors.Should().Contain(e => e.PropertyName == nameof(request.City));
+    }
+
+    [Fact]
+    public void Validate_EmptyState_IsInvalid()
+    {
+        // Arrange
+        var request = ValidRequest();
+        request.State = string.Empty;
+
+        // Act
+        var result = _validator.Validate(request);
+
+        // Assert
+        result.IsValid.Should().BeFalse();
+        result.Errors.Should().Contain(e => e.PropertyName == nameof(request.State));
+    }
+
+    [Theory]
+    [InlineData("notanemail")]
+    [InlineData("@nodomain.com")]
+    [InlineData("trailing.dot@example.com.")]
+    [InlineData("")]
+    public void Validate_InvalidEmail_IsInvalid(string email)
+    {
+        // Arrange
+        var request = ValidRequest();
+        request.Email = email;
+
+        // Act
+        var result = _validator.Validate(request);
+
+        // Assert
+        result.IsValid.Should().BeFalse();
+        result.Errors.Should().Contain(e => e.PropertyName == nameof(request.Email));
+    }
+
+    [Fact]
+    public void Validate_EmptyPhone_IsInvalid()
+    {
+        // Arrange
+        var request = ValidRequest();
+        request.Phone = string.Empty;
+
+        // Act
+        var result = _validator.Validate(request);
+
+        // Assert
+        result.IsValid.Should().BeFalse();
+        result.Errors.Should().Contain(e => e.PropertyName == nameof(request.Phone));
+    }
+
+    [Fact]
+    public void Validate_EmptyBankName_IsInvalid()
+    {
+        // Arrange
+        var request = ValidRequest();
+        request.BankName = string.Empty;
+
+        // Act
+        var result = _validator.Validate(request);
+
+        // Assert
+        result.IsValid.Should().BeFalse();
+        result.Errors.Should().Contain(e => e.PropertyName == nameof(request.BankName));
+    }
+
+    [Fact]
+    public void Validate_EmptyBankNumber_IsInvalid()
+    {
+        // Arrange
+        var request = ValidRequest();
+        request.BankNumber = string.Empty;
+
+        // Act
+        var result = _validator.Validate(request);
+
+        // Assert
+        result.IsValid.Should().BeFalse();
+        result.Errors.Should().Contain(e => e.PropertyName == nameof(request.BankNumber));
+    }
+}

--- a/tests/xUnitTests/Validators/User/UserAddValidatorTest.cs
+++ b/tests/xUnitTests/Validators/User/UserAddValidatorTest.cs
@@ -1,0 +1,115 @@
+using Contracts.Requests.User;
+using FluentAssertions;
+using Validators.User;
+
+namespace xUnitTests.Validators.User;
+
+public class UserAddValidatorTest
+{
+    private readonly UserAddValidator _validator = new();
+
+    private static UserAddRequest ValidRequest() => new()
+    {
+        Name = "John",
+        LastName = "Doe",
+        Email = "john.doe@example.com",
+        Password = "password123"
+    };
+
+    [Fact]
+    public void Validate_ValidRequest_IsValid()
+    {
+        // Arrange
+        var request = ValidRequest();
+
+        // Act
+        var result = _validator.Validate(request);
+
+        // Assert
+        result.IsValid.Should().BeTrue();
+    }
+
+    [Fact]
+    public void Validate_EmptyName_IsInvalid()
+    {
+        // Arrange
+        var request = ValidRequest();
+        request.Name = string.Empty;
+
+        // Act
+        var result = _validator.Validate(request);
+
+        // Assert
+        result.IsValid.Should().BeFalse();
+        result.Errors.Should().Contain(e => e.PropertyName == nameof(request.Name));
+    }
+
+    [Fact]
+    public void Validate_EmptyLastName_IsInvalid()
+    {
+        // Arrange
+        var request = ValidRequest();
+        request.LastName = string.Empty;
+
+        // Act
+        var result = _validator.Validate(request);
+
+        // Assert
+        result.IsValid.Should().BeFalse();
+        result.Errors.Should().Contain(e => e.PropertyName == nameof(request.LastName));
+    }
+
+    [Theory]
+    [InlineData("notanemail")]
+    [InlineData("@nodomain.com")]
+    [InlineData("trailing.dot@example.com.")]
+    [InlineData("")]
+    public void Validate_InvalidEmail_IsInvalid(string email)
+    {
+        // Arrange
+        var request = ValidRequest();
+        request.Email = email;
+
+        // Act
+        var result = _validator.Validate(request);
+
+        // Assert
+        result.IsValid.Should().BeFalse();
+        result.Errors.Should().Contain(e => e.PropertyName == nameof(request.Email));
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("abc")]
+    [InlineData("short")]
+    public void Validate_WeakPassword_IsInvalid(string password)
+    {
+        // Arrange
+        var request = ValidRequest();
+        request.Password = password;
+
+        // Act
+        var result = _validator.Validate(request);
+
+        // Assert
+        result.IsValid.Should().BeFalse();
+        result.Errors.Should().Contain(e => e.PropertyName == nameof(request.Password));
+    }
+
+    [Theory]
+    [InlineData("password1")]
+    [InlineData("longenoughpassword")]
+    [InlineData("12345678")]
+    public void Validate_SufficientPassword_IsValid(string password)
+    {
+        // Arrange
+        var request = ValidRequest();
+        request.Password = password;
+
+        // Act
+        var result = _validator.Validate(request);
+
+        // Assert
+        result.IsValid.Should().BeTrue();
+    }
+}

--- a/tests/xUnitTests/Validators/User/UserLoginValidatorTest.cs
+++ b/tests/xUnitTests/Validators/User/UserLoginValidatorTest.cs
@@ -1,0 +1,63 @@
+using Contracts.Requests.User;
+using FluentAssertions;
+using Validators.User;
+
+namespace xUnitTests.Validators.User;
+
+public class UserLoginValidatorTest
+{
+    private readonly UserLoginValidator _validator = new();
+
+    [Fact]
+    public void Validate_ValidRequest_IsValid()
+    {
+        // Arrange
+        var request = new UserLoginRequest
+        {
+            Email = "user@example.com",
+            Password = "somepassword"
+        };
+
+        // Act
+        var result = _validator.Validate(request);
+
+        // Assert
+        result.IsValid.Should().BeTrue();
+    }
+
+    [Fact]
+    public void Validate_EmptyEmail_IsInvalid()
+    {
+        // Arrange
+        var request = new UserLoginRequest
+        {
+            Email = string.Empty,
+            Password = "somepassword"
+        };
+
+        // Act
+        var result = _validator.Validate(request);
+
+        // Assert
+        result.IsValid.Should().BeFalse();
+        result.Errors.Should().Contain(e => e.PropertyName == nameof(request.Email));
+    }
+
+    [Fact]
+    public void Validate_EmptyPassword_IsInvalid()
+    {
+        // Arrange
+        var request = new UserLoginRequest
+        {
+            Email = "user@example.com",
+            Password = string.Empty
+        };
+
+        // Act
+        var result = _validator.Validate(request);
+
+        // Assert
+        result.IsValid.Should().BeFalse();
+        result.Errors.Should().Contain(e => e.PropertyName == nameof(request.Password));
+    }
+}

--- a/tests/xUnitTests/Validators/User/UserUpdateValidatorTest.cs
+++ b/tests/xUnitTests/Validators/User/UserUpdateValidatorTest.cs
@@ -1,0 +1,75 @@
+using Contracts.Requests.User;
+using FluentAssertions;
+using Validators.User;
+
+namespace xUnitTests.Validators.User;
+
+public class UserUpdateValidatorTest
+{
+    private readonly UserUpdateValidator _validator = new();
+
+    private static UserUpdateRequest ValidRequest() => new()
+    {
+        Id = Guid.NewGuid(),
+        Name = "John",
+        LastName = "Doe"
+    };
+
+    [Fact]
+    public void Validate_ValidRequest_IsValid()
+    {
+        // Arrange
+        var request = ValidRequest();
+
+        // Act
+        var result = _validator.Validate(request);
+
+        // Assert
+        result.IsValid.Should().BeTrue();
+    }
+
+    [Fact]
+    public void Validate_EmptyId_IsInvalid()
+    {
+        // Arrange
+        var request = ValidRequest();
+        request.Id = Guid.Empty;
+
+        // Act
+        var result = _validator.Validate(request);
+
+        // Assert
+        result.IsValid.Should().BeFalse();
+        result.Errors.Should().Contain(e => e.PropertyName == nameof(request.Id));
+    }
+
+    [Fact]
+    public void Validate_EmptyName_IsInvalid()
+    {
+        // Arrange
+        var request = ValidRequest();
+        request.Name = string.Empty;
+
+        // Act
+        var result = _validator.Validate(request);
+
+        // Assert
+        result.IsValid.Should().BeFalse();
+        result.Errors.Should().Contain(e => e.PropertyName == nameof(request.Name));
+    }
+
+    [Fact]
+    public void Validate_EmptyLastName_IsInvalid()
+    {
+        // Arrange
+        var request = ValidRequest();
+        request.LastName = string.Empty;
+
+        // Act
+        var result = _validator.Validate(request);
+
+        // Assert
+        result.IsValid.Should().BeFalse();
+        result.Errors.Should().Contain(e => e.PropertyName == nameof(request.LastName));
+    }
+}


### PR DESCRIPTION
Covers CustomerAdd/Update, InvoiceAdd/Generate/Item/ItemUpdate/Update, ItemAdd/Update, SellerAdd/Update, UserAdd/Login/Update validators. Each test class includes a valid happy-path case and individual failure cases for every rule (empty fields, invalid email, out-of-range numbers, date ordering). Sub-validator exception propagation is verified with Assert.Throws<ValidationException>.